### PR TITLE
Add hasRole admin function and update grantRole for DEFAULT_ADMIN_ROLE

### DIFF
--- a/src/commands/admin/hasrole.ts
+++ b/src/commands/admin/hasrole.ts
@@ -2,11 +2,11 @@ import { HashZero } from "@ethersproject/constants";
 import { Arg } from "@oclif/core/lib/interfaces";
 import { ethers } from "ethers";
 import { TransactionCommand } from "../../base";
-import { getSigner, parseAddress, pretty, run } from "../../helpers";
+import { getProvider, parseAddress } from "../../helpers";
 
 const DEFAULT_ADMIN_ROLE = "DEFAULT_ADMIN_ROLE";
 
-export default class GrantRole extends TransactionCommand {
+export default class HasRole extends TransactionCommand {
   static summary = "Grant a role to an account on the Armada Network.";
   static examples = [
     "<%= config.bin %> <%= command.id %> RECONCILER_ROLE 0x0000000000000000000000000000000000000000 0xContractAddress",
@@ -19,23 +19,26 @@ export default class GrantRole extends TransactionCommand {
   ];
 
   public async run(): Promise<unknown> {
-    const { args, flags } = await this.parse(GrantRole);
+    const { args, flags } = await this.parse(HasRole);
 
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
-    const abi = ["function grantRole(bytes32 role, address account) external"];
-    const contract = new ethers.Contract(args.CONTRACT_ADDRESS, abi, signer);
+    const provider = await getProvider(flags.network, flags.rpc);
+    const abi = ["function hasRole(bytes32 role, address account) external view returns (bool)"];
 
     // The value of DEFAULT_ADMIN_ROLE is HashZero, otherwise hash the role name to get the value
     const role = args.ROLE === DEFAULT_ADMIN_ROLE ? HashZero : ethers.utils.id(args.ROLE);
     const account = parseAddress(args.ACCOUNT);
 
-    try {
-      const tx = await contract.populateTransaction.grantRole(role, account);
-      const output = await run(tx, signer, [contract]);
-      this.log(pretty(output));
-      return output;
-    } catch (e) {
-      this.error(`Error granting role`);
+    const myContract = new ethers.Contract(args.CONTRACT_ADDRESS, abi, provider);
+    const contract = myContract.connect(provider);
+
+    const hasAdminRole = await contract.hasRole(role, account);
+
+    if (hasAdminRole) {
+      console.log(`${account} has the role ${args.ROLE}`);
+      return true;
+    } else {
+      console.log(`${account} does not have the role ${args.ROLE}`);
+      return false;
     }
   }
 }


### PR DESCRIPTION
This PR does two things
1. update grantRole to support DEFAULT_ADMIN_ROLE
2. add hasRole function to check if a wallet has a specified role

The DEFAULT_ADMIN_ROLE does not use the keccak256 hash, instead it's just 0x00, so that's why it's special case'd to HashZero